### PR TITLE
Change css var customization pattern to have default and custom

### DIFF
--- a/link.html
+++ b/link.html
@@ -4,29 +4,43 @@
 	<template>
 		<style include="vui-colors"></style>
 		<style>
+			:root {
+				--vui-link-default: {
+					color: var(--vui-color-celestine);
+					font-weight: normal;
+					text-decoration: none;
+					cursor: pointer;
+				}
+				--vui-link-main-default: {
+					font-weight: 700;
+				}
+				--vui-link-small-default: {
+					font-size: 0.7rem;
+					font-weight: 400;
+					line-height: 1rem;
+					letter-spacing: 0.02rem;
+				}
+				--vui-link-hover-default: {
+					color: var(--vui-color-celestuba);
+					text-decoration: underline;
+					outline-width: 0;
+				}
+			}
 			:host, :host(:visited), :host(:active), :host(:link) {
-				color: var(--vui-color-celestine);
-				font-weight: normal;
-				text-decoration: none;
-				cursor: pointer;
-				@apply(--vui-link);
+				@apply(--vui-link-default);
+				@apply(--vui-link-custom);
 			}
 			:host([main]) {
-				font-weight: 700;
-				@apply(--vui-link-main);
+				@apply(--vui-link-main-default);
+				@apply(--vui-link-main-custom);
 			}
 			:host([small]) {
-				font-size: 0.7rem;
-				font-weight: 400;
-				line-height: 1rem;
-				letter-spacing: 0.02rem;
-				@apply(--vui-link-small);
+				@apply(--vui-link-small-default);
+				@apply(--vui-link-small-custom);
 			}
 			:host(:hover), :host(:focus), :host(.vui-link-focus) {
-				color: var(--vui-color-celestuba);
-				text-decoration: underline;
-				outline-width: 0;
-				@apply(--vui-link-hover);
+				@apply(--vui-link-hover-default);
+				@apply(--vui-link-hover-custom);
 			}
 		</style>
 		<content></content>


### PR DESCRIPTION
So this PR is just something for consideration and I can certainly see valid arguments for not wanting to use the pattern suggested in it - so no worries if it is rejected (as always, really).

IMO, and in theory, I like the idea of having a var in our WCs for both default and custom styles.  It would allow a consumer to replace all styles, if it suits them.  Or to just extend.

So for something like link, this is kind of silly.  Why would you use the link WC if you don't want the base styles?  But for a more complicated WC down the road, I can see this potentially being helpful.  Maybe we want radically different styles for an html editor, for example, depending on where it is included.  

YAGNI might apply though.  But, still, I think this is a more flexible pattern for us to establish and use as we start to create more WCs.

On the downside the code looks slightly yuckier to me.

@dbatiste @dlockhart 